### PR TITLE
Fix umd build broken for node window is undefined

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,7 +10,8 @@ module.exports = {
   output: {
     filename: 'addsearch-search-ui.min.js',
     library: 'AddSearchUI',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'this'
   },
   mode: 'production',
   optimization: {


### PR DESCRIPTION
Hi 👋 

Importing addsearch-search-ui npm package from for example Next.js will cause an error `window is undefined` during server-rendering when in node where window is unavailable.

I debugged by running this locally, setting minimize to false and noticed that the umd build itself had a reference to `window`. Looking at this webpack issue about it https://github.com/webpack/webpack/issues/6784#issuecomment-557449449 you can see that setting `output.globalObject` to `'this'` should solve it. And the error went away for me. 🎉 