### PR TITLE
fix: [sc-9691] Search UI library drops GET parameters if there are more then one with the same name

### DIFF
--- a/src/util/history.js
+++ b/src/util/history.js
@@ -203,8 +203,20 @@ export function queryParamsToObject(url) {
 
   let obj = {};
   const qsArr = qs.split('&');
+  const qsArrUnrelated = qsArr.filter(v =>
+    v.indexOf(HISTORY_PARAMETERS.SEARCH) === -1 &&
+    v.indexOf(HISTORY_PARAMETERS.PAGE) === -1 &&
+    v.indexOf(HISTORY_PARAMETERS.SORTBY) === -1 &&
+    v.indexOf(HISTORY_PARAMETERS.FILTERS) === -1 &&
+    v.indexOf(HISTORY_PARAMETERS.FACETS) === -1 &&
+    v.indexOf(HISTORY_PARAMETERS.RANGE_FACETS) === -1);
+  const qsArrUsedInSearch = qsArr.filter(v => !qsArrUnrelated.includes(v));
 
-  qsArr.forEach(v => {
+  if (qsArrUnrelated.length) {
+    obj['addsearchUnrelatedParams'] = qsArrUnrelated.join(',');
+  }
+
+  qsArrUsedInSearch.forEach(v => {
     const kv = v.split('=');
     if (kv[0] && kv[0].length > 0) {
       let value = null;
@@ -233,7 +245,12 @@ export function objectToQueryParams(obj) {
         qs = qs + '&';
       }
       let value = '';
-      if (obj[key] !== null && obj[key] !== undefined) {
+      if (key === 'addsearchUnrelatedParams') {
+        const unrelatedParams = obj[key].split(',');
+        qs = qs + unrelatedParams.join('&');
+        continue;
+      }
+      if (obj[key] !== null && obj[key] !== undefined && key !== 'addsearchUnrelatedParams') {
         value = '=' + encodeURIComponent(obj[key]);
       }
       qs = qs + key + value;

--- a/test/util/history.js
+++ b/test/util/history.js
@@ -51,9 +51,9 @@ describe('history', () => {
     });
 
     it('return a bunch of query parameter', () => {
-      const url = 'https://addsearch.com/test?search=b%C3%B6&search_page=3&foo=bar';
+      const url = 'https://addsearch.com/test?search=b%C3%B6&search_page=3&foo=bar&foo=bar2';
       const expectedValue = {
-        addsearchUnrelatedParams: 'foo=bar',
+        addsearchUnrelatedParams: 'foo=bar,foo=bar2',
         search: 'bö',
         search_page: '3',
       };

--- a/test/util/history.js
+++ b/test/util/history.js
@@ -35,27 +35,27 @@ describe('history', () => {
     });
 
     it('return a single query parameter', () => {
-      const url = 'https://addsearch.com/test?foo=bar';
+      const url = 'https://addsearch.com/test?search=foo';
       const expectedValue = {
-        foo: 'bar'
+        search: 'foo'
       };
       assert.deepEqual(queryParamsToObject(url), expectedValue);
     });
 
     it('return a single query parameter with space', () => {
-      const url = 'https://addsearch.com/test?foo=bar+bar';
+      const url = 'https://addsearch.com/test?search=foo+bar';
       const expectedValue = {
-        foo: 'bar bar'
+        search: 'foo bar'
       };
       assert.deepEqual(queryParamsToObject(url), expectedValue);
     });
 
     it('return a bunch of query parameter', () => {
-      const url = 'https://addsearch.com/test?foo=bar&a=b&bar=b%C3%B6';
+      const url = 'https://addsearch.com/test?search=b%C3%B6&search_page=3&foo=bar';
       const expectedValue = {
-        foo: 'bar',
-        bar: 'bö',
-        a: 'b'
+        addsearchUnrelatedParams: 'foo=bar',
+        search: 'bö',
+        search_page: '3',
       };
       assert.deepEqual(queryParamsToObject(url), expectedValue);
     });


### PR DESCRIPTION
Story details: https://app.shortcut.com/addsearch/story/9691