### PR TITLE
add types for npm import with types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,69 @@
+declare module "addsearch-search-ui" {
+  export default class AddSearchUI {
+    constructor(client: any, settings?: any);
+    start(): void;
+    executeSearch(
+      keyword: string,
+      options?: any,
+      appendResults?: boolean,
+      fieldForInstantRedirect?: string,
+      fieldForInstantRedirectInConfiguration?: string
+    ): void;
+    fetchRecommendation(containerId: string): void;
+    searchField(conf: any): void;
+    autocomplete(conf: any): void;
+    searchResults(conf: any): void;
+    segmentedSearchResults(conf: any): void;
+    facets(conf: any): void;
+    hierarchicalFacets(conf: any): void;
+    rangeFacets(conf: any): void;
+    filters(conf: any): void;
+    sortBy(conf: any): void;
+    pagination(conf: any): void;
+    loadMore(conf: any): void;
+    activeFilters(conf: any): void;
+    recommendations(conf: any): void;
+    search(keyword: string): void;
+    hideAutocomplete(): void;
+    clear(): void;
+    registerHandlebarsHelper(name: string, helper: Function): void;
+    registerHandlebarsPartial(name: string, partial: string): void;
+  }
+
+  export const AUTOCOMPLETE_TYPE: {
+    SEARCH: string;
+    SUGGESTIONS: string;
+    CUSTOM_FIELDS: string;
+  };
+
+  export const FILTER_TYPE: {
+    CHECKBOX_GROUP: string;
+    RADIO_GROUP: string;
+    SELECT_LIST: string;
+    RANGE: string;
+    TABS: string;
+    TAGS: string;
+  };
+
+  export const SORTBY_TYPE: {
+    SELECT_LIST: string;
+    RADIO_GROUP: string;
+  };
+
+  export const LOAD_MORE_TYPE: {
+    BUTTON: string;
+    INFINITE_SCROLL: string;
+  };
+
+  export const RECOMMENDATION_TYPE: {
+    FREQUENTLY_BOUGHT_TOGETHER: string;
+    RELATED_ITEMS: string;
+  };
+
+  export const RANGE_FACETS_TYPE: {
+    CHECKBOX: string;
+    SLIDER: string;
+  };
+
+  export const Handlebars_runtime: any;
+}

--- a/package.json
+++ b/package.json
@@ -2,17 +2,6 @@
   "name": "addsearch-search-ui",
   "version": "0.8.15",
   "description": "JavaScript library to develop Search UIs for the web",
-  "main": "./dist/addsearch-search-ui.min.js",
-  "jsdelivr": "./dist/addsearch-search-ui.min.js",
-  "scripts": {
-    "test": "node node_modules/.bin/mocha --recursive --require @babel/register --require ignore-styles",
-    "build": "npm run test && ./node_modules/webpack-cli/bin/cli.js",
-    "watch": "./node_modules/webpack-cli/bin/cli.js --watch  --env development"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/AddSearch/search-ui.git"
-  },
   "keywords": [
     "addsearch",
     "search",
@@ -24,6 +13,11 @@
   ],
   "homepage": "https://www.addsearch.com/",
   "bugs": "https://github.com/AddSearch/search-ui/issues",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/AddSearch/search-ui.git"
+  },
+  "license": "MIT",
   "author": {
     "name": "AddSearch",
     "url": "https://www.addsearch.com"
@@ -34,13 +28,24 @@
       "url": "https://www.addsearch.com"
     }
   ],
+  "main": "./dist/addsearch-search-ui.min.js",
+  "jsdelivr": "./dist/addsearch-search-ui.min.js",
+  "types": "index.d.ts",
+  "files": [
+    "dist",
+    "index.d.ts"
+  ],
+  "scripts": {
+    "build": "npm run test && ./node_modules/webpack-cli/bin/cli.js",
+    "test": "node node_modules/.bin/mocha --recursive --require @babel/register --require ignore-styles",
+    "watch": "./node_modules/webpack-cli/bin/cli.js --watch  --env development"
+  },
   "browserslist": [
     "> 0.1%",
     "IE 9",
     "last 2 versions",
     "not dead"
   ],
-  "license": "MIT",
   "dependencies": {
     "es6-object-assign": "^1.1.0",
     "handlebars": "^4.7.7",


### PR DESCRIPTION
This way addsearch-search-ui package can be imported into Typescript projects with type interface for the default export AddSearchUI provided.